### PR TITLE
logic to show data from day ago fixed, cron-job pushed up

### DIFF
--- a/javascripts/app-logic.js
+++ b/javascripts/app-logic.js
@@ -12,9 +12,7 @@ let assets = require("./assets/asset-loader"),
 // -This Week's Biggest Movers
 
 // get data for the day (or fallback to yesterday's data)
-getData.charts().then( unparsed => {
-  // after there is data, parse it
-  let data = JSON.parse(unparsed);
+getData.charts().then( data => {
 
   // Top 10% Movement Chart
   if (data.movementWeek10) { // check that the data's there first

--- a/javascripts/get-data/crawler-data/charts.js
+++ b/javascripts/get-data/crawler-data/charts.js
@@ -12,16 +12,25 @@ let baseURL       = "https://bggstats-2de27.firebaseio.com",
     backup        = getToday(1); // today minus 1 day
 
 let getCharts = () => {
-  if (!isDataEmpty(getData(`${baseURL}${collection}/${subcollection}.json`))) {
-    // if today's data is there return today's data
-    let today = getData(`${baseURL}${collection}/${subcollection}.json`);
-    return today;
-  } else {
-    // if it doesn't exist, return yesterday's data
-    let yesterday = getData(`${baseURL}${collection}/${backup}.json`);
-    console.log("data from today not found. serving data from yesterday");
-    return yesterday;
-  }
+
+  let today = getData(`${baseURL}${collection}/${subcollection}.json`);
+
+  return today.then( todayRawData => {
+    let todayData = JSON.parse(todayRawData);
+    let doesTodayHaveData = !isDataEmpty(todayData);
+    console.log("today have data?", doesTodayHaveData);
+    if (doesTodayHaveData) {
+      // if today's data is there return today's data
+      return todayData;
+    } else {
+      // if it doesn't exist, return yesterday's data
+      let yesterday = getData(`${baseURL}${collection}/${backup}.json`);
+      return yesterday.then( yesterdayRawData => {
+        console.log("Crawl data from today not found. Serving data from yesterday.");
+        return JSON.parse(yesterdayRawData);
+      });
+    }
+  });
 };
 
 module.exports = getCharts;

--- a/public/bundle.js
+++ b/public/bundle.js
@@ -109,9 +109,7 @@
 	// -This Week's Biggest Movers
 
 	// get data for the day (or fallback to yesterday's data)
-	getData.charts().then( unparsed => {
-	  // after there is data, parse it
-	  let data = JSON.parse(unparsed);
+	getData.charts().then( data => {
 
 	  // Top 10% Movement Chart
 	  if (data.movementWeek10) { // check that the data's there first
@@ -35364,16 +35362,25 @@
 	    backup        = getToday(1); // today minus 1 day
 
 	let getCharts = () => {
-	  if (!isDataEmpty(getData(`${baseURL}${collection}/${subcollection}.json`))) {
-	    // if today's data is there return today's data
-	    let today = getData(`${baseURL}${collection}/${subcollection}.json`);
-	    return today;
-	  } else {
-	    // if it doesn't exist, return yesterday's data
-	    let yesterday = getData(`${baseURL}${collection}/${backup}.json`);
-	    console.log("data from today not found. serving data from yesterday");
-	    return yesterday;
-	  }
+
+	  let today = getData(`${baseURL}${collection}/${subcollection}.json`);
+
+	  return today.then( todayRawData => {
+	    let todayData = JSON.parse(todayRawData);
+	    let doesTodayHaveData = !isDataEmpty(todayData);
+	    console.log("today have data?", doesTodayHaveData);
+	    if (doesTodayHaveData) {
+	      // if today's data is there return today's data
+	      return todayData;
+	    } else {
+	      // if it doesn't exist, return yesterday's data
+	      let yesterday = getData(`${baseURL}${collection}/${backup}.json`);
+	      return yesterday.then( yesterdayRawData => {
+	        console.log("Crawl data from today not found. Serving data from yesterday.");
+	        return JSON.parse(yesterdayRawData);
+	      });
+	    }
+	  });
 	};
 
 	module.exports = getCharts;


### PR DESCRIPTION
- my check to see if the database had data to draw charts for the day failed. It was checking unparsed data so wasn't a true check. fixed.

- cron-job triggers the crawler at 4a and not 1:30a now. It seemed like my crawler was crawler about the time bgg reset rankings for the day so there were instances in which i was comparing the same set of data over 24 hours.