### PR TITLE
firefox charts fix

### DIFF
--- a/public/bundle.js
+++ b/public/bundle.js
@@ -11751,7 +11751,7 @@
 
 	got.stream = (url, opts) => asStream(normalizeArguments(url, opts));
 
-	for (const el of helpers) {
+	for (let el of helpers) {
 		got.stream[el] = (url, opts) => got.stream(url, Object.assign({}, opts, {method: el}));
 	}
 


### PR DESCRIPTION
This is a fix for #214. The node module 'got' is using const rather than let in a 'for of' which some versions of firefox doesn't like.

in `node_modules/got/index.js` line 323