### PR TITLE
crawler restarts again if it doesn't start the first time

### DIFF
--- a/javascripts/cron-jobs/daily-backup.js
+++ b/javascripts/cron-jobs/daily-backup.js
@@ -1,0 +1,26 @@
+// a cron job configured with heroku triggers this file at 10:30 UTC (4:30 am central) every day, 30 minutes after waking up the daily crawler.
+
+// this file checks if rankings are being pushed up to the database yet. If not, the crawler is triggered again in case the first attempt failed.
+
+"use strict";
+
+// requires
+let getData = require("../get-data/get-data-loader"),
+    getToday = require("../assets/get-date"),
+    isDataEmpty = require("../assets/empty-data-checker");
+
+let today = getToday();
+
+getData.rankings(today).then( rankingsToday => {
+    let areThereRankingsToday = !isDataEmpty(rankingsToday);
+    if (areThereRankingsToday) {
+      console.log(`:: `);
+      console.log(`:: ✓ Cron job checking if rankings are coming in. Yup.`);
+      console.log(`:: `);
+    } else {
+      console.log(`:: `);
+      console.log(`:: ERROR: Crawler didn't start after first cron job. Rebooting...`);
+      console.log(`:: `);
+      require("../crawler/rankings-crawler");
+    }
+});


### PR DESCRIPTION
The crawler was triggered this morning by a cron job, but the crawler didn't start. I worked fine after a manual reboot. This code adds a second file that a 2nd cron job triggers 30 minutes after the first to make sure rankings data is being pushed up. Cron jobs are configured in heroku.

1. Cron job 1 triggers `cron-jobs/daily.js` at 10:00 UTC (4:00 am central).
2. Cron job 2 triggers `cron-jobs/daily-backup.js` at 10:30 UTC (4:30 am central).